### PR TITLE
re-enabled feature: optionally using wkof

### DIFF
--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -40,6 +40,13 @@
     font-size: 16px;
 }
 
+.wk_namespace li[class$="_meaning"] {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    padding: 0 5px;
+}
+
 .wk_namespace ul.single-character-grid li[id|=kanji],
 .wk_namespace ul.multi-character-grid  li[id|=kanji] {
     background-color:#f100a1;
@@ -93,7 +100,7 @@
 .wk_namespace ul.single-character-grid li.character-item.locked,
 .wk_namespace ul.single-character-grid li.character-item.notInWK,
 .wk_namespace ul.multi-character-grid  li.character-item.locked {
-    background-image:url("https://cdn-staging.wanikani.com/assets/default-v2/stripes-5e8494366c1615da046bd0f587cfeef6786e7ba17863df1329767ca3b89140e0.png");
+    background-image:url("https://cdn.wanikani.com/assets/default-v2/stripes-901d93ece56dde9dac14fbbd8363cb53599460bc350251140b631660865fd9be.png");
     background-repeat:repeat
 }
 

--- a/wanikani-phonetic-compounds/wk_keisei.user.js
+++ b/wanikani-phonetic-compounds/wk_keisei.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WaniKani Keisei Phonetic-Semantic Composition
-// @version     1.8.9
+// @version     1.8.10
 // @author      acm
 // @description Adds information to Wanikani about kanji that use Phonetic-Semantic Composition.
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -18,13 +18,13 @@
 //
 // @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-phonetic-compounds/css/keisei.css
 //
-// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/css/chargrid.css
+// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/styles/css/chargrid.css
 // @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/bootstrap/css/bootstrap.crop.css
 // @resource    bootstrapjs  https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/bootstrap/js/bootstrap.js
 //
 // @require     https://cdn.jsdelivr.net/npm/lodash@4.17.4/lodash.min.js
 //
-// @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=962341
+// @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=969075
 //
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-phonetic-compounds/wk_keisei.db.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-phonetic-compounds/wk_keisei.strings.en.js

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -147,8 +147,8 @@ function WK_Niai()
 
         $(`#niai_similar_grid`).html(char_list.map(this.gen_item_chargrid).join(``));
 
-        if (false && unsafeWindow.wkof)
-            this.wkof_fix_info(similar_list);
+        if (typeof wkof === `object`)
+            this.update_wk_cache(similar_list);
 
         if (!$(`#niai_badges_btn i`).hasClass(`icon-remove-circle`))
         {
@@ -191,9 +191,9 @@ function WK_Niai()
 
         this.ndb = new NiaiDB();
 
-        if ($(`li.dropdown.levels`).length)
+        if (options[`Current Level`])
         {
-            this.settings.user_level = parseInt($(`li.levels a span`).text());
+            this.settings.user_level = options[`Current Level`];
             GM_setValue(`user_level`, this.settings.user_level);
         }
 

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.9
+// @version     1.3.10
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -26,18 +26,18 @@
 //
 // @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/master/wanikani-similar-kanji/css/wk_niai.css
 //
-// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/css/chargrid.css
-// @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/bootstrap/css/bootstrap.crop.css
+// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/styles/css/chargrid.css
+// @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/styles/bootstrap/css/bootstrap.crop.css
 //
-// @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/bootstrap/js/bootstrap.js
-// @resource    b-dropdown-js  https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/styles/bootstrap/js/bootstrap-dropdown.js
+// @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/styles/bootstrap/js/bootstrap.js
+// @resource    b-dropdown-js  https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/styles/bootstrap/js/bootstrap-dropdown.js
 //
-// @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=962341
+// @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=969075
 //
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-similar-kanji/wk_niai.db.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-similar-kanji/wk_niai.modal.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-similar-kanji/wk_niai.html.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9613d7da06618c4f55519ae1edbc9c706db13a59/wanikani-similar-kanji/wk_niai.main.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/wanikani-similar-kanji/wk_niai.db.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/wanikani-similar-kanji/wk_niai.modal.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/wanikani-similar-kanji/wk_niai.html.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c063a359e4308a28887769c58e958fa3ca600ff5/wanikani-similar-kanji/wk_niai.main.js
 //
 // @grant       GM_log
 // @grant       GM_getValue


### PR DESCRIPTION
Use WaniKani Open Framework to overwrite outdated info. The items are only queried at the start of the lesson/review session to prevent the wkof loading popup problem that led to the removal of the wkof feature. Also fixed the display of locked items in Niai.