### PR TITLE
[似合い] Sort similar Kanji list by WK level

### DIFF
--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -109,14 +109,24 @@ function WK_Niai()
 
     const sort_by_level = function(kanjiA,kanjiB)
     {
-        // kanjis not in DB should be shown last
+        // kanjis not in DB -> move to end
         const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
         const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
-        if (!kanjiA_inDB && !kanjiB)
+        if (!kanjiA_inDB && !kanjiB_inDB)
             return 0;
-        else if (kanjiA_inDB && !kanjiB)
+        else if (kanjiA_inDB && !kanjiB_inDB)
             return -1;
-        else if (!kanjiA_inDB && kanjiB)
+        else if (!kanjiA_inDB && kanjiB_inDB)
+            return 1;
+        
+        // treat kanji not in WK as a level over 60
+        const kanjiA_inWK = this.ndb.isKanjiInWK(kanjiA);
+        const kanjiB_inWK = this.ndb.isKanjiInWK(kanjiB);
+        if (!kanjiA_inWK && !kanjiB_inWK)
+            return 0;
+        else if (kanjiA_inWK && !kanjiB_inWK)
+            return -1;
+        else if (!kanjiA_inWK && kanjiB_inWK)
             return 1;
         
         // sort by ascending level
@@ -131,16 +141,16 @@ function WK_Niai()
 
     const sort_by_score = function(kanjiA,kanjiB)
     {
-        // kanjis not in DB should be shown last
+        // kanjis not in DB -> move to end
         const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
         const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
-        if (!kanjiA_inDB && !kanjiB)
+        if (!kanjiA_inDB && !kanjiB_inDB)
             return 0;
-        else if (kanjiA_inDB && !kanjiB)
+        else if (kanjiA_inDB && !kanjiB_inDB)
             return -1;
-        else if (!kanjiA_inDB && kanjiB)
+        else if (!kanjiA_inDB && kanjiB_inDB)
             return 1;
-        
+
         // sort by descending score
         const kanjiA_score = this.ndb.getInfo(kanjiA).score;
         const kanjiB_score = this.ndb.getInfo(kanjiB).score;
@@ -149,6 +159,39 @@ function WK_Niai()
         if (kanjiA_score > kanjiB_score)
             return -1;
         return 0;
+    };
+
+    const sort_by_locked_status = function(kanjiA,kanjiB)
+    {
+        // kanjis not in DB -> move to end
+        const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
+        const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
+        if (!kanjiA_inDB && !kanjiB_inDB)
+            return 0;
+        else if (kanjiA_inDB && !kanjiB_inDB)
+            return -1;
+        else if (!kanjiA_inDB && kanjiB_inDB)
+            return 1;
+
+        // treat kanji not in WK as locked "for ever" -> show last
+        const kanjiA_inWK = this.ndb.isKanjiInWK(kanjiA);
+        const kanjiB_inWK = this.ndb.isKanjiInWK(kanjiB);
+        if (!kanjiA_inWK && !kanjiB_inWK)
+            return 0;
+        else if (kanjiA_inWK && !kanjiB_inWK)
+            return -1;
+        else if (!kanjiA_inWK && kanjiB_inWK)
+            return 1;
+
+        // kanjis locked should be shown last
+        const kanjiA_islocked = this.ndb.isKanjiLocked(kanjiA,this.settings.user_level);
+        const kanjiB_islocked = this.ndb.isKanjiLocked(kanjiB,this.settings.user_level);
+        if (!kanjiA_islocked && !kanjiB_islocked)
+            return 0;
+        else if (kanjiA_islocked && !kanjiB_islocked)
+            return -1;
+        else if (!kanjiA_islocked && kanjiB_islocked)
+            return 1;
     };
 
     // #########################################################################

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -189,9 +189,9 @@ function WK_Niai()
         if (!kanjiA_islocked && !kanjiB_islocked)
             return 0;
         else if (kanjiA_islocked && !kanjiB_islocked)
-            return -1;
-        else if (!kanjiA_islocked && kanjiB_islocked)
             return 1;
+        else if (!kanjiA_islocked && kanjiB_islocked)
+            return -1;
     };
 
     // #########################################################################
@@ -206,7 +206,7 @@ function WK_Niai()
 
         // sort similar kanji by: score, level, ...
         var similar_kanji = this.ndb.getSimilar(kanji,this.settings.user_level,use_sources,this.settings.min_score);
-        similar_kanji.sort(sort_by_score.bind(this));
+        // similar_kanji.sort(sort_by_score.bind(this)); // DB is already sorted by score, therefore no need to do it again
         // similar_kanji.sort(sort_by_level.bind(this));
         similar_kanji.sort(sort_by_locked_status.bind(this));
 

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -117,13 +117,31 @@ function WK_Niai()
         if (this.settings.use_alt)
             use_sources = [...this.settings.alt_sources, ...use_sources];
 
-        const similar_list = [kanji,
-                              ...this.ndb.getSimilar(kanji,
-                                                     this.settings.user_level,
-                                                     use_sources,
-                                                     this.settings.min_score)];
-        let char_list = [];
+        // sort similar kanji by level
+        var similar_kanji = this.ndb.getSimilar(kanji,this.settings.user_level,use_sources,this.settings.min_score);
+        similar_kanji.sort(function(kanjiA,kanjiB) {
+            // kanjis not in DB should be shown last
+            const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
+            const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
+            if (!kanjiA_inDB && !kanjiB)
+                return 0;
+            else if (kanjiA_inDB && !kanjiB)
+                return -1;
+            else if (!kanjiA_inDB && kanjiB)
+                return 1;
+            
+            // sort by ascending level
+            const kanjiA_level = this.ndb.getInfo(kanjiA).level;
+            const kanjiB_level = this.ndb.getInfo(kanjiB).level;
+            if (kanjiA_level < kanjiB_level)
+                return -1;
+            if (kanjiA_level > kanjiB_level)
+                return 1;
+            return 0;
+        });
 
+        const similar_list = [kanji,...similar_kanji];
+        let char_list = [];
         similar_list.forEach(
             function(sim_kanji, i)
             {

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -119,15 +119,15 @@ function WK_Niai()
         else if (!kanjiA_inDB && kanjiB_inDB)
             return 1;
         
-        // treat kanji not in WK as a level over 60
-        const kanjiA_inWK = this.ndb.isKanjiInWK(kanjiA);
-        const kanjiB_inWK = this.ndb.isKanjiInWK(kanjiB);
-        if (!kanjiA_inWK && !kanjiB_inWK)
-            return 0;
-        else if (kanjiA_inWK && !kanjiB_inWK)
-            return -1;
-        else if (!kanjiA_inWK && kanjiB_inWK)
-            return 1;
+        // // treat kanji not in WK as a level over 60
+        // const kanjiA_inWK = this.ndb.isKanjiInWK(kanjiA);
+        // const kanjiB_inWK = this.ndb.isKanjiInWK(kanjiB);
+        // if (!kanjiA_inWK && !kanjiB_inWK)
+        //     return 0;
+        // else if (kanjiA_inWK && !kanjiB_inWK)
+        //     return -1;
+        // else if (!kanjiA_inWK && kanjiB_inWK)
+        //     return 1;
         
         // sort by ascending level
         const kanjiA_level = this.ndb.getInfo(kanjiA).level;
@@ -173,15 +173,15 @@ function WK_Niai()
         else if (!kanjiA_inDB && kanjiB_inDB)
             return 1;
 
-        // treat kanji not in WK as locked "for ever" -> show last
-        const kanjiA_inWK = this.ndb.isKanjiInWK(kanjiA);
-        const kanjiB_inWK = this.ndb.isKanjiInWK(kanjiB);
-        if (!kanjiA_inWK && !kanjiB_inWK)
-            return 0;
-        else if (kanjiA_inWK && !kanjiB_inWK)
-            return -1;
-        else if (!kanjiA_inWK && kanjiB_inWK)
-            return 1;
+        // // treat kanji not in WK as locked "for ever" -> show last
+        // const kanjiA_inWK = this.ndb.isKanjiInWK(kanjiA);
+        // const kanjiB_inWK = this.ndb.isKanjiInWK(kanjiB);
+        // if (!kanjiA_inWK && !kanjiB_inWK)
+        //     return 0;
+        // else if (kanjiA_inWK && !kanjiB_inWK)
+        //     return -1;
+        // else if (!kanjiA_inWK && kanjiB_inWK)
+        //     return 1;
 
         // kanjis locked should be shown last
         const kanjiA_islocked = this.ndb.isKanjiLocked(kanjiA,this.settings.user_level);
@@ -192,6 +192,7 @@ function WK_Niai()
             return 1;
         else if (!kanjiA_islocked && kanjiB_islocked)
             return -1;
+        return 0;
     };
 
     // #########################################################################

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -163,8 +163,8 @@ function WK_Niai()
 
         // sort similar kanji by: score, level, ...
         var similar_kanji = this.ndb.getSimilar(kanji,this.settings.user_level,use_sources,this.settings.min_score);
-        similar_kanji.sort((kanjiA,kanjiB) => sort_by_score(kanjiA,kanjiB).bind(this));
-        // similar_kanji.sort((kanjiA,kanjiB) => sort_by_level(kanjiA,kanjiB).bind(this));
+        similar_kanji.sort(sort_by_score.bind(this));
+        // similar_kanji.sort(sort_by_level.bind(this));
 
         const similar_list = [kanji,...similar_kanji];
         let char_list = [];

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -208,6 +208,7 @@ function WK_Niai()
         var similar_kanji = this.ndb.getSimilar(kanji,this.settings.user_level,use_sources,this.settings.min_score);
         similar_kanji.sort(sort_by_score.bind(this));
         // similar_kanji.sort(sort_by_level.bind(this));
+        similar_kanji.sort(sort_by_locked_status.bind(this));
 
         const similar_list = [kanji,...similar_kanji];
         let char_list = [];

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -119,26 +119,28 @@ function WK_Niai()
 
         // sort similar kanji by level
         var similar_kanji = this.ndb.getSimilar(kanji,this.settings.user_level,use_sources,this.settings.min_score);
-        similar_kanji.sort(function(kanjiA,kanjiB) {
-            // kanjis not in DB should be shown last
-            const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
-            const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
-            if (!kanjiA_inDB && !kanjiB)
+        similar_kanji.sort(
+            function(kanjiA,kanjiB) {
+                // kanjis not in DB should be shown last
+                const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
+                const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
+                if (!kanjiA_inDB && !kanjiB)
+                    return 0;
+                else if (kanjiA_inDB && !kanjiB)
+                    return -1;
+                else if (!kanjiA_inDB && kanjiB)
+                    return 1;
+                
+                // sort by ascending level
+                const kanjiA_level = this.ndb.getInfo(kanjiA).level;
+                const kanjiB_level = this.ndb.getInfo(kanjiB).level;
+                if (kanjiA_level < kanjiB_level)
+                    return -1;
+                if (kanjiA_level > kanjiB_level)
+                    return 1;
                 return 0;
-            else if (kanjiA_inDB && !kanjiB)
-                return -1;
-            else if (!kanjiA_inDB && kanjiB)
-                return 1;
-            
-            // sort by ascending level
-            const kanjiA_level = this.ndb.getInfo(kanjiA).level;
-            const kanjiB_level = this.ndb.getInfo(kanjiB).level;
-            if (kanjiA_level < kanjiB_level)
-                return -1;
-            if (kanjiA_level > kanjiB_level)
-                return 1;
-            return 0;
-        });
+            }.bind(this)
+        );
 
         const similar_list = [kanji,...similar_kanji];
         let char_list = [];

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -107,6 +107,50 @@ function WK_Niai()
         return result;
     };
 
+    const sort_by_level = function(kanjiA,kanjiB)
+    {
+        // kanjis not in DB should be shown last
+        const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
+        const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
+        if (!kanjiA_inDB && !kanjiB)
+            return 0;
+        else if (kanjiA_inDB && !kanjiB)
+            return -1;
+        else if (!kanjiA_inDB && kanjiB)
+            return 1;
+        
+        // sort by ascending level
+        const kanjiA_level = this.ndb.getInfo(kanjiA).level;
+        const kanjiB_level = this.ndb.getInfo(kanjiB).level;
+        if (kanjiA_level < kanjiB_level)
+            return -1;
+        if (kanjiA_level > kanjiB_level)
+            return 1;
+        return 0;
+    };
+
+    const sort_by_score = function(kanjiA,kanjiB)
+    {
+        // kanjis not in DB should be shown last
+        const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
+        const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
+        if (!kanjiA_inDB && !kanjiB)
+            return 0;
+        else if (kanjiA_inDB && !kanjiB)
+            return -1;
+        else if (!kanjiA_inDB && kanjiB)
+            return 1;
+        
+        // sort by descending score
+        const kanjiA_score = this.ndb.getInfo(kanjiA).score;
+        const kanjiB_score = this.ndb.getInfo(kanjiB).score;
+        if (kanjiA_score < kanjiB_score)
+            return 1;
+        if (kanjiA_score > kanjiB_score)
+            return -1;
+        return 0;
+    };
+
     // #########################################################################
     WK_Niai.prototype.populateNiaiSection = function(kanji, curPage)
     {
@@ -117,30 +161,10 @@ function WK_Niai()
         if (this.settings.use_alt)
             use_sources = [...this.settings.alt_sources, ...use_sources];
 
-        // sort similar kanji by level
+        // sort similar kanji by: score, level, ...
         var similar_kanji = this.ndb.getSimilar(kanji,this.settings.user_level,use_sources,this.settings.min_score);
-        similar_kanji.sort(
-            function(kanjiA,kanjiB) {
-                // kanjis not in DB should be shown last
-                const kanjiA_inDB = this.ndb.isKanjiInDB(kanjiA);
-                const kanjiB_inDB = this.ndb.isKanjiInDB(kanjiB);
-                if (!kanjiA_inDB && !kanjiB)
-                    return 0;
-                else if (kanjiA_inDB && !kanjiB)
-                    return -1;
-                else if (!kanjiA_inDB && kanjiB)
-                    return 1;
-                
-                // sort by ascending level
-                const kanjiA_level = this.ndb.getInfo(kanjiA).level;
-                const kanjiB_level = this.ndb.getInfo(kanjiB).level;
-                if (kanjiA_level < kanjiB_level)
-                    return -1;
-                if (kanjiA_level > kanjiB_level)
-                    return 1;
-                return 0;
-            }.bind(this)
-        );
+        similar_kanji.sort((kanjiA,kanjiB) => sort_by_score(kanjiA,kanjiB).bind(this));
+        // similar_kanji.sort((kanjiA,kanjiB) => sort_by_level(kanjiA,kanjiB).bind(this));
 
         const similar_list = [kanji,...similar_kanji];
         let char_list = [];


### PR DESCRIPTION
Addresses feature request #22.
Similar Kanji are now sorted in ascending WK level order.

Before change:
<img width="1561" alt="Unsorted Kanji List" src="https://user-images.githubusercontent.com/59295964/212426473-add9fe87-e687-44ec-a048-6250342ff92b.png">

After change:
<img width="1563" alt="Sorted Kanji List" src="https://user-images.githubusercontent.com/59295964/212426511-8ce50e21-0a9e-4308-a966-4a3914a71342.png">
