### PR TITLE
Update to Keisei stylesheets to support native css variables and userstyles that override them

### DIFF
--- a/styles/bootstrap/css/bootstrap.crop.css
+++ b/styles/bootstrap/css/bootstrap.crop.css
@@ -348,7 +348,8 @@
     font-weight: normal;
     line-height: 20px;
     color: #333;
-    white-space: nowrap
+    white-space: nowrap;
+    cursor: pointer;
 }
 
 .wk_namespace .dropdown-menu>li>a:hover,

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -43,6 +43,13 @@
     font-size: 16px;
 }
 
+.wk_namespace li[class$="_meaning"] {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    padding: 0 5px;
+}
+
 .wk_namespace ul.single-character-grid li[id|=kanji],
 .wk_namespace ul.multi-character-grid li[id|=kanji] {
     background-color: var(--color-kanji, #f100a1);

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -123,8 +123,8 @@
     text-decoration: none;
 }
 
-.wk_niai ul.single-character-grid li.character-item a::after,
-.wk_niai ul.multi-character-grid li.character-item a::after {
+.wk_namespace ul.single-character-grid li.character-item a::after,
+.wk_namespace ul.multi-character-grid li.character-item a::after {
     content: "";
     position: absolute;
     top: 0;

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -100,7 +100,7 @@
 .wk_namespace ul.multi-character-grid li.character-item {
     display: inline-block;
     position: relative;
-    width: 116px;
+    width: 112px;
     color: var(--color-character-text, #fff);
     text-align: center;
 }

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -1,449 +1,341 @@
 .wk_namespace ul,
 .wk_namespace ol {
     font-size: 14px;
-    padding:0;
-    margin:0 0 10px 25px
+    padding: 0;
+    margin: 0 0 10px 25px;
 }
 
 .wk_namespace h2,
 .wk_namespace h3 {
     display: flex;
     flex-wrap: wrap;
-    align-items: center
+    align-items: center;
 }
 
 .wk_namespace h2 .btn-group:first-child,
 .wk_namespace h3 .btn-group:first-child {
-    margin-left: auto
+    margin-left: auto;
 }
 
 .wk_namespace ul {
-    display: block
+    display: block;
 }
 
 .wk_namespace ul li {
     margin-bottom: 0;
-    display: block
+    display: block;
 }
 
 .wk_namespace ul li span {
     padding-left: 0;
-    padding-right: 0
+    padding-right: 0;
 }
 
 .wk_namespace div > ul {
-    text-align: left
+    text-align: left;
 }
 
 .wk_namespace a {
-    text-decoration:none
+    text-decoration: none;
 }
 
 .wk_namespace ul.radical {
     font-size: 16px;
 }
 
-.wk_namespace li[class$="_meaning"] {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    padding: 0 5px;
-}
-
 .wk_namespace ul.single-character-grid li[id|=kanji],
-.wk_namespace ul.multi-character-grid  li[id|=kanji] {
-    background-color:#f100a1;
-    background-image:-moz-linear-gradient(top, #f0a, #dd0093);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#f0a), to(#dd0093));
-    background-image:-webkit-linear-gradient(top, #f0a, #dd0093);
-    background-image:-o-linear-gradient(top, #f0a, #dd0093);
-    background-image:linear-gradient(to bottom, #f0a, #dd0093);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFF00AA', endColorstr='#FFDD0093', GradientType=0);
-    border-top:1px solid #f6c;
-    border-bottom:1px solid #cc0088;
-    border-left:1px solid #f6c
+.wk_namespace ul.multi-character-grid li[id|=kanji] {
+    background-color: var(--color-kanji, #f100a1);
+    background-image: linear-gradient(var(--color-kanji-gradient, (to bottom, #f0a, #dd0093)));
 }
 
 .wk_namespace ul.single-character-grid li[id|=radical],
-.wk_namespace ul.multi-character-grid  li[id|=radical] {
-    background-color:#00a1f1;
-    background-image:-moz-linear-gradient(top, #0af, #0093dd);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#0af), to(#0093dd));
-    background-image:-webkit-linear-gradient(top, #0af, #0093dd);
-    background-image:-o-linear-gradient(top, #0af, #0093dd);
-    background-image:linear-gradient(to bottom, #0af, #0093dd);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF00AAFF', endColorstr='#FF0093DD', GradientType=0);
-    border-top:1px solid #88d7ff;
-    border-bottom:1px solid #069;
-    border-left:1px solid #88d7ff
+.wk_namespace ul.multi-character-grid li[id|=radical] {
+    background-color: var(--color-radical, #00a1f1);
+    background-image: linear-gradient(var(--color-radical-gradient, (to bottom, #0af, #0093dd)));
 }
 
 .wk_namespace ul.single-character-grid li[id|=vocabulary],
-.wk_namespace ul.multi-character-grid  li[id|=vocabulary] {
-    background-color:#a100f1;
-    background-image:-moz-linear-gradient(top, #a0f, #9300dd);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#a0f), to(#9300dd));
-    background-image:-webkit-linear-gradient(top, #a0f, #9300dd);
-    background-image:-o-linear-gradient(top, #a0f, #9300dd);
-    background-image:linear-gradient(to bottom, #a0f, #9300dd);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFAA00FF', endColorstr='#FF9300DD', GradientType=0);
-    border-top:1px solid #c655ff;
-    border-bottom:1px solid #8800cc;
-    border-left:1px solid #c655ff
+.wk_namespace ul.multi-character-grid li[id|=vocabulary] {
+    background-color: var(--color-vocabulary, #a100f1);
+    background-image: linear-gradient(var(--color-vocabulary-gradient, (to bottom, #a0f, #9300dd)));
 }
 
 .wk_namespace ul.single-character-grid,
 .wk_namespace ul.multi-character-grid {
-    margin:0
+    margin: 0;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.locked,
 .wk_namespace ul.single-character-grid li.character-item.notInWK,
-.wk_namespace ul.multi-character-grid  li.character-item.locked {
-    background-image:url("https://cdn.wanikani.com/assets/default-v2/stripes-901d93ece56dde9dac14fbbd8363cb53599460bc350251140b631660865fd9be.png");
-    background-repeat:repeat
+.wk_namespace ul.multi-character-grid li.character-item.locked {
+    background-image: url("https://cdn.wanikani.com/assets/default-v2/stripes-901d93ece56dde9dac14fbbd8363cb53599460bc350251140b631660865fd9be.png");
+    background-repeat: repeat;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.locked.kanji,
 .wk_namespace ul.single-character-grid li.character-item.notInWK.kanji,
-.wk_namespace ul.multi-character-grid  li.character-item.locked.kanji {
-    background-color:#f0a;
-    background-image:none;
-    background-repeat:no-repeat;
-    filter:none
+.wk_namespace ul.multi-character-grid li.character-item.locked.kanji {
+    background-color: var(--color-kanji, #f0a);
+    background-image: none;
+    background-repeat: no-repeat;
+    filter: none;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.burned,
-.wk_namespace ul.multi-character-grid  li.character-item.burned {
-    background-color:#505050;
-    background-image:-moz-linear-gradient(top, #555, #484848);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#555), to(#484848));
-    background-image:-webkit-linear-gradient(top, #555, #484848);
-    background-image:-o-linear-gradient(top, #555, #484848);
-    background-image:linear-gradient(to bottom, #555, #484848);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF555555', endColorstr='#FF484848', GradientType=0);
-    border-top:1px solid #555;
-    border-bottom:1px solid #333;
-    border-left:1px solid #555;
-    -webkit-box-shadow:0 10px 10px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow:0 10px 10px rgba(0,0,0,0.4) inset;
-    box-shadow:0 10px 10px rgba(0,0,0,0.4) inset
+.wk_namespace ul.multi-character-grid li.character-item.burned {
+    background-color: var(--color-burned, #505050);
+    background-image: linear-gradient(var(--color-burned-gradient, (to bottom, #555, #484848)));
+    box-shadow: 0 10px 10px rgba(0, 0, 0, 0.4) inset;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.burned span.character,
 .wk_namespace ul.single-character-grid li.character-item.burned ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item.burned span.character,
-.wk_namespace ul.multi-character-grid  li.character-item.burned ul>li {
-    opacity:0.4;
-    filter:alpha(opacity=40)
+.wk_namespace ul.multi-character-grid li.character-item.burned span.character,
+.wk_namespace ul.multi-character-grid li.character-item.burned ul>li {
+    opacity: 0.4;
 }
 
 .wk_namespace ul.single-character-grid li.character-item,
-.wk_namespace ul.multi-character-grid  li.character-item {
-    display:inline-block;
-    position:relative;
-    width:116px;
-    color:#ffffff;
-    padding:0;
-    text-align:center
+.wk_namespace ul.multi-character-grid li.character-item {
+    display: inline-block;
+    position: relative;
+    width: 116px;
+    color: var(--color-character-text, #fff);
+    text-align: center;
 }
 
 .wk_namespace ul.single-character-grid li.character-item span.character,
-.wk_namespace ul.multi-character-grid  li.character-item span.character {
-    font-size:72px;
-    line-height:1.5em;
-    text-shadow:0 2px 0 rgba(0,0,0,0.3)
+.wk_namespace ul.multi-character-grid li.character-item span.character {
+    font-size: 72px;
+    line-height: 1.5em;
+    text-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .wk_namespace ul.single-character-grid li.character-item a,
-.wk_namespace ul.multi-character-grid  li.character-item a {
-    display:block;
-    color:inherit
+.wk_namespace ul.multi-character-grid li.character-item a {
+    display: block;
+    color: inherit;
 }
 
 .wk_namespace ul.single-character-grid li.character-item a:hover,
-.wk_namespace ul.multi-character-grid  li.character-item a:hover {
-    text-decoration:none
+.wk_namespace ul.multi-character-grid li.character-item a:hover {
+    text-decoration: none;
 }
 
 .wk_namespace ul.single-character-grid li.character-item ul,
-.wk_namespace ul.multi-character-grid  li.character-item ul {
-    margin:0;
-    padding-bottom:10px
+.wk_namespace ul.multi-character-grid li.character-item ul {
+    margin: 0;
+    padding-bottom: 10px;
 }
 
 .wk_namespace ul.single-character-grid li.character-item ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item ul>li {
-    display:block;
-    font-weight:400;
-    line-height:1.5em;
-    text-shadow:0 1px 0 rgba(0,0,0,0.3)
+.wk_namespace ul.multi-character-grid li.character-item ul>li {
+    display: block;
+    font-weight: 400;
+    line-height: 1.5em;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .wk_namespace ul.single-character-grid li.character-item ul>li:nth-child(2),
-.wk_namespace ul.multi-character-grid  li.character-item ul>li:nth-child(2) {
-    font-family:"Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif
+.wk_namespace ul.multi-character-grid li.character-item ul>li:nth-child(2) {
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .wk_namespace ul.single-character-grid li.character-item span.character,
 .wk_namespace ul.single-character-grid li.character-item ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item span.character,
-.wk_namespace ul.multi-character-grid  li.character-item ul>li {
-    -webkit-transition:text-shadow ease-out 0.3s;
-    -moz-transition:text-shadow ease-out 0.3s;
-    -o-transition:text-shadow ease-out 0.3s;
-    transition:text-shadow ease-out 0.3s
+.wk_namespace ul.multi-character-grid li.character-item span.character,
+.wk_namespace ul.multi-character-grid li.character-item ul>li {
+    transition: text-shadow ease-out 0.3s;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:hover ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item:hover ul>li {
-    text-shadow:0 1px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.multi-character-grid li.character-item:hover ul>li {
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:hover span.character,
-.wk_namespace ul.multi-character-grid  li.character-item:hover span.character {
-    text-shadow:0 2px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.multi-character-grid li.character-item:hover span.character {
+    text-shadow: 0 2px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:active,
-.wk_namespace ul.multi-character-grid  li.character-item:active {
-    -webkit-box-shadow:0 15px 15px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow:0 15px 15px rgba(0,0,0,0.4) inset;
-    box-shadow:0 15px 15px rgba(0,0,0,0.4) inset
+.wk_namespace ul.multi-character-grid li.character-item:active {
+    box-shadow: 0 15px 15px rgba(0, 0, 0, 0.4) inset;
 }
 
-.wk_namespace ul.single-character-grid li.character-item:active ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item:active ul>li {
-    text-shadow:0 1px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.single-character-grid li.character-item:active ul > li,
+.wk_namespace ul.multi-character-grid li.character-item:active ul > li {
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:active span.character,
-.wk_namespace ul.multi-character-grid  li.character-item:active span.character {
-    text-shadow:0 -2px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.multi-character-grid li.character-item:active span.character {
+    text-shadow: 0 -2px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
-
-
 
 .wk_namespace ul.multi-character-grid li[id|=radical] img {
     width: 25px;
-    height: 25px
+    height: 25px;
 }
 
-.wk_namespace ul.multi-character-grid li[id|=radical] ul>li:first-child {
-    display: none !important
+.wk_namespace ul.multi-character-grid li[id|=radical] ul > li:first-child {
+    display: none !important;
 }
 
-.wk_namespace ul.multi-character-grid li[id|=radical] ul>li:last-child {
-    line-height: 2.6em
+.wk_namespace ul.multi-character-grid li[id|=radical] ul > li:last-child {
+    line-height: 2.6em;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item {
     display: block;
     width: 100%;
     text-align: left;
-    border-left: none
+    border-left: none;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item a {
-    padding: 12px
+    padding: 12px;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item span.character {
     font-size: 27px;
-    line-height: 1em
+    line-height: 1em;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item ul {
-    display: inline-block;
+    display: block;
     float: right;
     text-align: right;
-    font-size: 10px
+    font-size: 10px;
 }
 
-.wk_namespace ul.multi-character-grid li.character-item ul>li {
-    line-height: 1.4em
+.wk_namespace ul.multi-character-grid li.character-item ul > li {
+    line-height: 1.4em;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item.burned {
     border-left: 0;
-    -webkit-box-shadow: 0 5px 5px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow: 0 5px 5px rgba(0,0,0,0.4) inset;
-    box-shadow: 0 5px 5px rgba(0,0,0,0.4) inset
+    box-shadow: 0 5px 5px rgba(0, 0, 0, 0.4) inset;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item:active {
-    -webkit-box-shadow: 0 8px 8px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow: 0 8px 8px rgba(0,0,0,0.4) inset;
-    box-shadow: 0 8px 8px rgba(0,0,0,0.4) inset
+    box-shadow: 0 8px 8px rgba(0, 0, 0, 0.4) inset;
 }
 
 .wk_namespace ul.multi-character-grid span.recently-unlocked-badge:before {
     top: 1.1em;
     left: -1.1em;
     font-size: 11px;
-    text-align: center
+    text-align: center;
 }
 
 .wk_namespace ul.multi-character-grid-extra-styling {
-    -webkit-border-radius: 3px;
-    -moz-border-radius: 3px;
     border-radius: 3px;
-    -webkit-box-shadow: 0 2px 0 rgba(0,0,0,0.3);
-    -moz-box-shadow: 0 2px 0 rgba(0,0,0,0.3);
-    box-shadow: 0 2px 0 rgba(0,0,0,0.3)
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .wk_namespace ul.multi-character-grid-extra-styling li.character-item:first-child {
-    -webkit-border-top-left-radius: 3px;
-    -moz-border-radius-topleft: 3px;
     border-top-left-radius: 3px;
-    -webkit-border-top-right-radius: 3px;
-    -moz-border-radius-topright: 3px;
-    border-top-right-radius: 3px
+    border-top-right-radius: 3px;
 }
 
 .wk_namespace ul.multi-character-grid-extra-styling li.character-item:last-child {
-    -webkit-border-bottom-left-radius: 3px;
-    -moz-border-radius-bottomleft: 3px;
     border-bottom-left-radius: 3px;
-    -webkit-border-bottom-right-radius: 3px;
-    -moz-border-radius-bottomright: 3px;
-    border-bottom-right-radius: 3px
+    border-bottom-right-radius: 3px;
 }
 
-
-@media (max-width: 767px)
-{
-    .wk_namespace ul.single-character-grid li[id|=radical] img
-    {
-        width:25px;
-        height:25px
+@media (max-width: 767px) {
+    .wk_namespace ul.single-character-grid li[id|=radical] img {
+        width: 25px;
+        height: 25px;
     }
 
-    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:first-child
-    {
-        display:none !important
+    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:first-child {
+        display: none !important;
     }
 
-    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:last-child
-    {
-        line-height:2.6em
+    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:last-child {
+        line-height: 2.6em;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item
-    {
-        display:block;
-        width:100%;
-        text-align:left;
-        border-left:none
+    .wk_namespace ul.single-character-grid li.character-item {
+        display: block;
+        width: 100%;
+        text-align: left;
+        border-left: none;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item a
-    {
-        padding:12px
+    .wk_namespace ul.single-character-grid li.character-item a {
+        padding: 12px;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item span.character
-    {
-        font-size:27px;
-        line-height:1em
+    .wk_namespace ul.single-character-grid li.character-item span.character {
+        font-size: 27px;
+        line-height: 1em;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item ul
-    {
-        display:inline-block;
-        float:right;
-        text-align:right;
-        font-size:10px
+    .wk_namespace ul.single-character-grid li.character-item ul {
+        display: block;
+        float: right;
+        text-align: right;
+        font-size: 10px;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item ul>li
-    {
-        line-height:1.4em
+    .wk_namespace ul.single-character-grid li.character-item ul > li {
+        line-height: 1.4em;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item.burned
-    {
-        border-left:0;
-        -webkit-box-shadow:0 5px 5px rgba(0,0,0,0.4) inset;
-        -moz-box-shadow:0 5px 5px rgba(0,0,0,0.4) inset;
-        box-shadow:0 5px 5px rgba(0,0,0,0.4) inset
+    .wk_namespace ul.single-character-grid li.character-item.burned {
+        border-left: 0;
+        box-shadow: 0 5px 5px rgba(0, 0, 0, 0.4) inset;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item:active
-    {
-        -webkit-box-shadow:0 8px 8px rgba(0,0,0,0.4) inset;
-        -moz-box-shadow:0 8px 8px rgba(0,0,0,0.4) inset;
-        box-shadow:0 8px 8px rgba(0,0,0,0.4) inset
+    .wk_namespace ul.single-character-grid li.character-item:active {
+        box-shadow: 0 8px 8px rgba(0, 0, 0, 0.4) inset;
     }
 
-    .wk_namespace ul.single-character-grid span.recently-unlocked-badge:before
-    {
-        top:1.1em;
-        left:-1.1em;
-        font-size:11px;
-        text-align:center
+    .wk_namespace ul.single-character-grid span.recently-unlocked-badge:before {
+        top: 1.1em;
+        left: -1.1em;
+        font-size: 11px;
+        text-align: center;
     }
 }
 
-.wk_namespace ul.multi-character-grid-extra-styling-767px
-{
-    -webkit-border-radius:3px;
-    -moz-border-radius:3px;
-    border-radius:3px;
-    -webkit-box-shadow:0 2px 0 rgba(0,0,0,0.3);
-    -moz-box-shadow:0 2px 0 rgba(0,0,0,0.3);
-    box-shadow:0 2px 0 rgba(0,0,0,0.3)
+.wk_namespace ul.multi-character-grid-extra-styling-767px {
+    border-radius: 3px;
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 
-.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:first-child
-{
-    -webkit-border-top-left-radius:3px;
-    -moz-border-radius-topleft:3px;
-    border-top-left-radius:3px;
-    -webkit-border-top-right-radius:3px;
-    -moz-border-radius-topright:3px;
-    border-top-right-radius:3px}
-
-.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:last-child
-{
-    -webkit-border-bottom-left-radius:3px;
-    -moz-border-radius-bottomleft:3px;
-    border-bottom-left-radius:3px;
-    -webkit-border-bottom-right-radius:3px;
-    -moz-border-radius-bottomright:3px;
-    border-bottom-right-radius:3px
+.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:first-child {
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
 }
 
-
-.wk_namespace .recently-unlocked-badge
-{
-    position:absolute;
-    left:0
+.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:last-child {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
 }
 
-.wk_namespace .recently-unlocked-badge:before
-{
-    display:block;
-    position:absolute;
-    top:-0.6em;
-    left:-0.6em;
-    width:2em;
-    height:2em;
-    color:#fff;
-    font-size:16px;
-    font-weight:normal;
-    line-height:2.2em;
-    text-shadow:0 2px 0 #99001f;
-    -webkit-box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    -moz-box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    -webkit-border-radius:50%;
-    -moz-border-radius:50%;
-    border-radius:50%;
-    z-index:999
+.wk_namespace .recently-unlocked-badge {
+    position: absolute;
+    left: 0;
+}
+
+.wk_namespace .recently-unlocked-badge:before {
+    display: block;
+    position: absolute;
+    top: -0.6em;
+    left: -0.6em;
+    width: 2em;
+    height: 2em;
+    color: #fff;
+    font-size: 16px;
+    font-weight: normal;
+    line-height: 2.2em;
+    text-shadow: 0 2px 0 #99001f;
+    box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.2) inset, 0 0 10px rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    z-index: 999;
 }

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -123,6 +123,20 @@
     text-decoration: none;
 }
 
+.wk_niai ul.single-character-grid li.character-item a::after,
+.wk_niai ul.multi-character-grid li.character-item a::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: #0000;
+    pointer-events: none;
+    border: 1px solid;
+    border-color: #FFF6 #0000 #3336 #FFF6;
+}
+
 .wk_namespace ul.single-character-grid li.character-item ul,
 .wk_namespace ul.multi-character-grid li.character-item ul {
     margin: 0;

--- a/wanikani-phonetic-compounds/css/keisei.css
+++ b/wanikani-phonetic-compounds/css/keisei.css
@@ -49,8 +49,9 @@
     color: darkorange;
 }
 
-.wk_namespace .keisei_alternative_reading {
+/*.wk_namespace .keisei_alternative_reading {
 }
+*/
 
 .wk_namespace .keisei_main_reading {
     font-weight: bold;
@@ -62,35 +63,21 @@
 
 /* #f0a -> 0c4, #dd0093 -> 092 */
 .wk_namespace ul.single-character-grid li[id|=phonetic],
-.wk_namespace ul.multi-character-grid  li[id|=phonetic]
-{
-    background-color:#0a2;
-    background-image:-moz-linear-gradient(top, #0c4, #092);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#0c4), to(#092));
-    background-image:-webkit-linear-gradient(top, #0c4, #092);
-    background-image:-o-linear-gradient(top, #0c4, #092);
-    background-image:linear-gradient(to bottom, #0c4, #092);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF00CC44', endColorstr='#FF009922', GradientType=0);
-    border-top:1px solid #0c4;
-    border-bottom:1px solid #092;
-    border-left:1px solid #0c4
+.wk_namespace ul.multi-character-grid li[id|=phonetic] {
+    background-color: #0a2;
+    background-image: linear-gradient(to bottom, #0c4, #092);
+    border-top: #0c4;
+    border-bottom: #092;
+    border-left: #0c4;
 }
 
 .wk_namespace ul.single-character-grid li[id|=nonphonetic],
-.wk_namespace ul.multi-character-grid  li[id|=nonphonetic]
-{
-    background-color:#f04;
-    background-image:-moz-linear-gradient(top, #f04, #c04);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#f04), to(#c04));
-    background-image:-webkit-linear-gradient(top, #f04, #c04);
-    background-image:-o-linear-gradient(top, #f04, #c04);
-    background-image:linear-gradient(to bottom, #f04, #c04);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFF0044', endColorstr='#FFCC0044', GradientType=0);
-    border-top:1px solid #f04;
-    border-bottom:1px solid #c04;
-    border-left:1px solid #f04
+.wk_namespace ul.multi-character-grid li[id|=nonphonetic] {
+    background-color: #f04;
+    background-image: linear-gradient(to bottom, #f04, #c04);
+    border-top: #f04;
+    border-bottom: #c04;
+    border-left: #f04;
 }
 
 .wk_namespace .keisei_spaced_chargrid {
@@ -102,6 +89,7 @@
 .wk_namespace .keisei_phonetic_grid {
     display: flex;
     flex-direction: row;
+    margin-top: 15px;
     padding-bottom: 10px;
     margin-bottom: 6px;
     border-bottom: 1px solid #d5d5d5;
@@ -111,7 +99,15 @@
     display: flex;
     flex-wrap: nowrap;
     flex-direction: row;
-    margin-right: 10px !important;
+    margin-right: 20px !important;
+}
+
+.wk_namespace .keisei_phongrid_header li.character-item {
+    height: fit-content;
+}
+
+.wk_namespace .keisei_phongrid_header li.character-item {
+    height: fit-content;
 }
 
 .wk_namespace .keisei_phongrid_compounds {
@@ -120,8 +116,7 @@
     flex-wrap: wrap;
 }
 
-@media (max-width: 767px)
-{
+@media (max-width: 767px) {
     .wk_namespace .keisei_phonetic_grid,
     .wk_namespace .keisei_spaced_chargrid {
         flex-direction: column;
@@ -138,7 +133,7 @@
     }
 }
 
-html#main .navbar .nav li.phonetic.dropdown.open>.dropdown-toggle {
+html#main .navbar .nav li.phonetic.dropdown.open > .dropdown-toggle {
     background-color: #0c4;
 }
 
@@ -146,14 +141,14 @@ html#main .navbar .phonetic .dropdown-menu {
     background-color: #0a2;
 }
 
-html#main .navbar .nav>li.phonetic>.dropdown-menu:after {
+html#main .navbar .nav > li.phonetic > .dropdown-menu:after {
     border-bottom: 8px solid #0a2;
 }
 
-html#main .navbar .nav>li.phonetic>a:hover>span:first-child {
+html#main .navbar .nav > li.phonetic > a:hover > span:first-child {
     border-color: #0a2;
 }
 
-html#main .navbar .nav>li.phonetic>a:hover {
+html#main .navbar .nav > li.phonetic > a:hover {
     color: #0a2;
 }

--- a/wanikani-phonetic-compounds/css/keisei.css
+++ b/wanikani-phonetic-compounds/css/keisei.css
@@ -66,18 +66,12 @@
 .wk_namespace ul.multi-character-grid li[id|=phonetic] {
     background-color: #0a2;
     background-image: linear-gradient(to bottom, #0c4, #092);
-    border-top: #0c4;
-    border-bottom: #092;
-    border-left: #0c4;
 }
 
 .wk_namespace ul.single-character-grid li[id|=nonphonetic],
 .wk_namespace ul.multi-character-grid li[id|=nonphonetic] {
     background-color: #f04;
     background-image: linear-gradient(to bottom, #f04, #c04);
-    border-top: #f04;
-    border-bottom: #c04;
-    border-left: #f04;
 }
 
 .wk_namespace .keisei_spaced_chargrid {

--- a/wanikani-phonetic-compounds/wk_keisei.user.js
+++ b/wanikani-phonetic-compounds/wk_keisei.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WaniKani Keisei Phonetic-Semantic Composition
-// @version     1.8.28
+// @version     1.8.29
 // @author      acm
 // @description Adds information to Wanikani about kanji that use Phonetic-Semantic Composition.
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -16,9 +16,9 @@
 // @resource    phonetic_db  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-phonetic-compounds/db/phonetic_esc.json
 // @resource    wk_kanji_db  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-phonetic-compounds/db/wk_kanji_esc.json
 //
-// @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/461d3fd84c193952826a7222378d49217d29020f/wanikani-phonetic-compounds/css/keisei.css
+// @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/c45eb62588535d072daf5f572f47d6b8a217b66c/wanikani-phonetic-compounds/css/keisei.css
 //
-// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/461d3fd84c193952826a7222378d49217d29020f/styles/css/chargrid.css
+// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c45eb62588535d072daf5f572f47d6b8a217b66c/styles/css/chargrid.css
 // @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/30e35798e7e61374017b211c3647600302df73dd/styles/bootstrap/css/bootstrap.crop.css
 // @resource    bootstrapjs  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
 //

--- a/wanikani-phonetic-compounds/wk_keisei.user.js
+++ b/wanikani-phonetic-compounds/wk_keisei.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WaniKani Keisei Phonetic-Semantic Composition
-// @version     1.8.31
+// @version     1.8.32
 // @author      acm
 // @description Adds information to Wanikani about kanji that use Phonetic-Semantic Composition.
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -18,7 +18,7 @@
 //
 // @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/c45eb62588535d072daf5f572f47d6b8a217b66c/wanikani-phonetic-compounds/css/keisei.css
 //
-// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/60be455419d65c13f704d0025a5b13747a6bddfb/styles/css/chargrid.css
+// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/03a8f7e7e5b6cd9e9430c83909110a72724eb63f/styles/css/chargrid.css
 // @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/30e35798e7e61374017b211c3647600302df73dd/styles/bootstrap/css/bootstrap.crop.css
 // @resource    bootstrapjs  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
 //

--- a/wanikani-phonetic-compounds/wk_keisei.user.js
+++ b/wanikani-phonetic-compounds/wk_keisei.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WaniKani Keisei Phonetic-Semantic Composition
-// @version     1.8.29
+// @version     1.8.30
 // @author      acm
 // @description Adds information to Wanikani about kanji that use Phonetic-Semantic Composition.
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -18,7 +18,7 @@
 //
 // @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/c45eb62588535d072daf5f572f47d6b8a217b66c/wanikani-phonetic-compounds/css/keisei.css
 //
-// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/c45eb62588535d072daf5f572f47d6b8a217b66c/styles/css/chargrid.css
+// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/d444118d9ff0b74491fd32c9c9fdb8356b913477/styles/css/chargrid.css
 // @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/30e35798e7e61374017b211c3647600302df73dd/styles/bootstrap/css/bootstrap.crop.css
 // @resource    bootstrapjs  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
 //

--- a/wanikani-phonetic-compounds/wk_keisei.user.js
+++ b/wanikani-phonetic-compounds/wk_keisei.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WaniKani Keisei Phonetic-Semantic Composition
-// @version     1.8.30
+// @version     1.8.31
 // @author      acm
 // @description Adds information to Wanikani about kanji that use Phonetic-Semantic Composition.
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -18,7 +18,7 @@
 //
 // @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/c45eb62588535d072daf5f572f47d6b8a217b66c/wanikani-phonetic-compounds/css/keisei.css
 //
-// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/d444118d9ff0b74491fd32c9c9fdb8356b913477/styles/css/chargrid.css
+// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/60be455419d65c13f704d0025a5b13747a6bddfb/styles/css/chargrid.css
 // @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/30e35798e7e61374017b211c3647600302df73dd/styles/bootstrap/css/bootstrap.crop.css
 // @resource    bootstrapjs  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
 //

--- a/wanikani-phonetic-compounds/wk_keisei.user.js
+++ b/wanikani-phonetic-compounds/wk_keisei.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WaniKani Keisei Phonetic-Semantic Composition
-// @version     1.8.24
+// @version     1.8.28
 // @author      acm
 // @description Adds information to Wanikani about kanji that use Phonetic-Semantic Composition.
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -16,10 +16,10 @@
 // @resource    phonetic_db  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-phonetic-compounds/db/phonetic_esc.json
 // @resource    wk_kanji_db  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-phonetic-compounds/db/wk_kanji_esc.json
 //
-// @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-phonetic-compounds/css/keisei.css
+// @resource    keisei_style https://raw.githubusercontent.com/mwil/wanikani-userscripts/461d3fd84c193952826a7222378d49217d29020f/wanikani-phonetic-compounds/css/keisei.css
 //
-// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/9e2c7070a8f277dcb372d2e04c60136cea14f81a/styles/css/chargrid.css
-// @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/3ecdbcadd04d0832ab98540eea5f918489841f41/styles/bootstrap/css/bootstrap.crop.css
+// @resource    chargrid     https://raw.githubusercontent.com/mwil/wanikani-userscripts/461d3fd84c193952826a7222378d49217d29020f/styles/css/chargrid.css
+// @resource    bootstrapcss https://raw.githubusercontent.com/mwil/wanikani-userscripts/30e35798e7e61374017b211c3647600302df73dd/styles/bootstrap/css/bootstrap.crop.css
 // @resource    bootstrapjs  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
 //
 // @require     https://cdn.jsdelivr.net/npm/lodash@4.17.4/lodash.min.js


### PR DESCRIPTION
I happen to be a user of a dark theme user style for Wanikani, in particular the recent update to Breeze Dark that Hubbit created, Breeze Dark 2, which is made in a way to make use of the native Wanikani css variables to decrease the likelihood of something in the style breaking as Wanikani can update the value the variable points to instead of changing the variable name (obvious a name change can, and has, happened, but it is much rarer than a change in the value itself).

When I installed this (and Niai) I realized right away that the scripts were not compatible with user styles in the slightest. So I wanted to update them to support the css variables and thus support any user style that takes the approach of overriding them. I also made some changes as I encountered things along the way and cleaned things up by removing the prefixed versions of some properties as the non-prefixed versions have been supported in all major browsers for some time now and this improves maintainability going forward.