### PR TITLE
Update to Niai stylesheets and fixes for a couple of small bugs I found

### DIFF
--- a/styles/bootstrap/css/bootstrap.crop.css
+++ b/styles/bootstrap/css/bootstrap.crop.css
@@ -348,7 +348,8 @@
     font-weight: normal;
     line-height: 20px;
     color: #333;
-    white-space: nowrap
+    white-space: nowrap;
+    cursor: pointer;
 }
 
 .wk_namespace .dropdown-menu>li>a:hover,

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -43,6 +43,13 @@
     font-size: 16px;
 }
 
+.wk_namespace li[class$="_meaning"] {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    padding: 0 5px;
+}
+
 .wk_namespace ul.single-character-grid li[id|=kanji],
 .wk_namespace ul.multi-character-grid li[id|=kanji] {
     background-color: var(--color-kanji, #f100a1);

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -123,8 +123,8 @@
     text-decoration: none;
 }
 
-.wk_niai ul.single-character-grid li.character-item a::after,
-.wk_niai ul.multi-character-grid li.character-item a::after {
+.wk_namespace ul.single-character-grid li.character-item a::after,
+.wk_namespace ul.multi-character-grid li.character-item a::after {
     content: "";
     position: absolute;
     top: 0;

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -100,7 +100,7 @@
 .wk_namespace ul.multi-character-grid li.character-item {
     display: inline-block;
     position: relative;
-    width: 116px;
+    width: 112px;
     color: var(--color-character-text, #fff);
     text-align: center;
 }

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -1,449 +1,341 @@
 .wk_namespace ul,
 .wk_namespace ol {
     font-size: 14px;
-    padding:0;
-    margin:0 0 10px 25px
+    padding: 0;
+    margin: 0 0 10px 25px;
 }
 
 .wk_namespace h2,
 .wk_namespace h3 {
     display: flex;
     flex-wrap: wrap;
-    align-items: center
+    align-items: center;
 }
 
 .wk_namespace h2 .btn-group:first-child,
 .wk_namespace h3 .btn-group:first-child {
-    margin-left: auto
+    margin-left: auto;
 }
 
 .wk_namespace ul {
-    display: block
+    display: block;
 }
 
 .wk_namespace ul li {
     margin-bottom: 0;
-    display: block
+    display: block;
 }
 
 .wk_namespace ul li span {
     padding-left: 0;
-    padding-right: 0
+    padding-right: 0;
 }
 
 .wk_namespace div > ul {
-    text-align: left
+    text-align: left;
 }
 
 .wk_namespace a {
-    text-decoration:none
+    text-decoration: none;
 }
 
 .wk_namespace ul.radical {
     font-size: 16px;
 }
 
-.wk_namespace li[class$="_meaning"] {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    padding: 0 5px;
-}
-
 .wk_namespace ul.single-character-grid li[id|=kanji],
-.wk_namespace ul.multi-character-grid  li[id|=kanji] {
-    background-color:#f100a1;
-    background-image:-moz-linear-gradient(top, #f0a, #dd0093);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#f0a), to(#dd0093));
-    background-image:-webkit-linear-gradient(top, #f0a, #dd0093);
-    background-image:-o-linear-gradient(top, #f0a, #dd0093);
-    background-image:linear-gradient(to bottom, #f0a, #dd0093);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFF00AA', endColorstr='#FFDD0093', GradientType=0);
-    border-top:1px solid #f6c;
-    border-bottom:1px solid #cc0088;
-    border-left:1px solid #f6c
+.wk_namespace ul.multi-character-grid li[id|=kanji] {
+    background-color: var(--color-kanji, #f100a1);
+    background-image: linear-gradient(var(--color-kanji-gradient, (to bottom, #f0a, #dd0093)));
 }
 
 .wk_namespace ul.single-character-grid li[id|=radical],
-.wk_namespace ul.multi-character-grid  li[id|=radical] {
-    background-color:#00a1f1;
-    background-image:-moz-linear-gradient(top, #0af, #0093dd);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#0af), to(#0093dd));
-    background-image:-webkit-linear-gradient(top, #0af, #0093dd);
-    background-image:-o-linear-gradient(top, #0af, #0093dd);
-    background-image:linear-gradient(to bottom, #0af, #0093dd);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF00AAFF', endColorstr='#FF0093DD', GradientType=0);
-    border-top:1px solid #88d7ff;
-    border-bottom:1px solid #069;
-    border-left:1px solid #88d7ff
+.wk_namespace ul.multi-character-grid li[id|=radical] {
+    background-color: var(--color-radical, #00a1f1);
+    background-image: linear-gradient(var(--color-radical-gradient, (to bottom, #0af, #0093dd)));
 }
 
 .wk_namespace ul.single-character-grid li[id|=vocabulary],
-.wk_namespace ul.multi-character-grid  li[id|=vocabulary] {
-    background-color:#a100f1;
-    background-image:-moz-linear-gradient(top, #a0f, #9300dd);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#a0f), to(#9300dd));
-    background-image:-webkit-linear-gradient(top, #a0f, #9300dd);
-    background-image:-o-linear-gradient(top, #a0f, #9300dd);
-    background-image:linear-gradient(to bottom, #a0f, #9300dd);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFAA00FF', endColorstr='#FF9300DD', GradientType=0);
-    border-top:1px solid #c655ff;
-    border-bottom:1px solid #8800cc;
-    border-left:1px solid #c655ff
+.wk_namespace ul.multi-character-grid li[id|=vocabulary] {
+    background-color: var(--color-vocabulary, #a100f1);
+    background-image: linear-gradient(var(--color-vocabulary-gradient, (to bottom, #a0f, #9300dd)));
 }
 
 .wk_namespace ul.single-character-grid,
 .wk_namespace ul.multi-character-grid {
-    margin:0
+    margin: 0;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.locked,
 .wk_namespace ul.single-character-grid li.character-item.notInWK,
-.wk_namespace ul.multi-character-grid  li.character-item.locked {
-    background-image:url("https://cdn.wanikani.com/assets/default-v2/stripes-901d93ece56dde9dac14fbbd8363cb53599460bc350251140b631660865fd9be.png");
-    background-repeat:repeat
+.wk_namespace ul.multi-character-grid li.character-item.locked {
+    background-image: url("https://cdn.wanikani.com/assets/default-v2/stripes-901d93ece56dde9dac14fbbd8363cb53599460bc350251140b631660865fd9be.png");
+    background-repeat: repeat;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.locked.kanji,
 .wk_namespace ul.single-character-grid li.character-item.notInWK.kanji,
-.wk_namespace ul.multi-character-grid  li.character-item.locked.kanji {
-    background-color:#f0a;
-    background-image:none;
-    background-repeat:no-repeat;
-    filter:none
+.wk_namespace ul.multi-character-grid li.character-item.locked.kanji {
+    background-color: var(--color-kanji, #f0a);
+    background-image: none;
+    background-repeat: no-repeat;
+    filter: none;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.burned,
-.wk_namespace ul.multi-character-grid  li.character-item.burned {
-    background-color:#505050;
-    background-image:-moz-linear-gradient(top, #555, #484848);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#555), to(#484848));
-    background-image:-webkit-linear-gradient(top, #555, #484848);
-    background-image:-o-linear-gradient(top, #555, #484848);
-    background-image:linear-gradient(to bottom, #555, #484848);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF555555', endColorstr='#FF484848', GradientType=0);
-    border-top:1px solid #555;
-    border-bottom:1px solid #333;
-    border-left:1px solid #555;
-    -webkit-box-shadow:0 10px 10px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow:0 10px 10px rgba(0,0,0,0.4) inset;
-    box-shadow:0 10px 10px rgba(0,0,0,0.4) inset
+.wk_namespace ul.multi-character-grid li.character-item.burned {
+    background-color: var(--color-burned, #505050);
+    background-image: linear-gradient(var(--color-burned-gradient, (to bottom, #555, #484848)));
+    box-shadow: 0 10px 10px rgba(0, 0, 0, 0.4) inset;
 }
 
 .wk_namespace ul.single-character-grid li.character-item.burned span.character,
 .wk_namespace ul.single-character-grid li.character-item.burned ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item.burned span.character,
-.wk_namespace ul.multi-character-grid  li.character-item.burned ul>li {
-    opacity:0.4;
-    filter:alpha(opacity=40)
+.wk_namespace ul.multi-character-grid li.character-item.burned span.character,
+.wk_namespace ul.multi-character-grid li.character-item.burned ul>li {
+    opacity: 0.4;
 }
 
 .wk_namespace ul.single-character-grid li.character-item,
-.wk_namespace ul.multi-character-grid  li.character-item {
-    display:inline-block;
-    position:relative;
-    width:116px;
-    color:#ffffff;
-    padding:0;
-    text-align:center
+.wk_namespace ul.multi-character-grid li.character-item {
+    display: inline-block;
+    position: relative;
+    width: 116px;
+    color: var(--color-character-text, #fff);
+    text-align: center;
 }
 
 .wk_namespace ul.single-character-grid li.character-item span.character,
-.wk_namespace ul.multi-character-grid  li.character-item span.character {
-    font-size:72px;
-    line-height:1.5em;
-    text-shadow:0 2px 0 rgba(0,0,0,0.3)
+.wk_namespace ul.multi-character-grid li.character-item span.character {
+    font-size: 72px;
+    line-height: 1.5em;
+    text-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .wk_namespace ul.single-character-grid li.character-item a,
-.wk_namespace ul.multi-character-grid  li.character-item a {
-    display:block;
-    color:inherit
+.wk_namespace ul.multi-character-grid li.character-item a {
+    display: block;
+    color: inherit;
 }
 
 .wk_namespace ul.single-character-grid li.character-item a:hover,
-.wk_namespace ul.multi-character-grid  li.character-item a:hover {
-    text-decoration:none
+.wk_namespace ul.multi-character-grid li.character-item a:hover {
+    text-decoration: none;
 }
 
 .wk_namespace ul.single-character-grid li.character-item ul,
-.wk_namespace ul.multi-character-grid  li.character-item ul {
-    margin:0;
-    padding-bottom:10px
+.wk_namespace ul.multi-character-grid li.character-item ul {
+    margin: 0;
+    padding-bottom: 10px;
 }
 
 .wk_namespace ul.single-character-grid li.character-item ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item ul>li {
-    display:block;
-    font-weight:400;
-    line-height:1.5em;
-    text-shadow:0 1px 0 rgba(0,0,0,0.3)
+.wk_namespace ul.multi-character-grid li.character-item ul>li {
+    display: block;
+    font-weight: 400;
+    line-height: 1.5em;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .wk_namespace ul.single-character-grid li.character-item ul>li:nth-child(2),
-.wk_namespace ul.multi-character-grid  li.character-item ul>li:nth-child(2) {
-    font-family:"Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif
+.wk_namespace ul.multi-character-grid li.character-item ul>li:nth-child(2) {
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .wk_namespace ul.single-character-grid li.character-item span.character,
 .wk_namespace ul.single-character-grid li.character-item ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item span.character,
-.wk_namespace ul.multi-character-grid  li.character-item ul>li {
-    -webkit-transition:text-shadow ease-out 0.3s;
-    -moz-transition:text-shadow ease-out 0.3s;
-    -o-transition:text-shadow ease-out 0.3s;
-    transition:text-shadow ease-out 0.3s
+.wk_namespace ul.multi-character-grid li.character-item span.character,
+.wk_namespace ul.multi-character-grid li.character-item ul>li {
+    transition: text-shadow ease-out 0.3s;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:hover ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item:hover ul>li {
-    text-shadow:0 1px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.multi-character-grid li.character-item:hover ul>li {
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:hover span.character,
-.wk_namespace ul.multi-character-grid  li.character-item:hover span.character {
-    text-shadow:0 2px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.multi-character-grid li.character-item:hover span.character {
+    text-shadow: 0 2px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:active,
-.wk_namespace ul.multi-character-grid  li.character-item:active {
-    -webkit-box-shadow:0 15px 15px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow:0 15px 15px rgba(0,0,0,0.4) inset;
-    box-shadow:0 15px 15px rgba(0,0,0,0.4) inset
+.wk_namespace ul.multi-character-grid li.character-item:active {
+    box-shadow: 0 15px 15px rgba(0, 0, 0, 0.4) inset;
 }
 
-.wk_namespace ul.single-character-grid li.character-item:active ul>li,
-.wk_namespace ul.multi-character-grid  li.character-item:active ul>li {
-    text-shadow:0 1px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.single-character-grid li.character-item:active ul > li,
+.wk_namespace ul.multi-character-grid li.character-item:active ul > li {
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
 
 .wk_namespace ul.single-character-grid li.character-item:active span.character,
-.wk_namespace ul.multi-character-grid  li.character-item:active span.character {
-    text-shadow:0 -2px 0 rgba(0,0,0,0.3),0 0 40px #fff
+.wk_namespace ul.multi-character-grid li.character-item:active span.character {
+    text-shadow: 0 -2px 0 rgba(0, 0, 0, 0.3), 0 0 40px #fff;
 }
-
-
 
 .wk_namespace ul.multi-character-grid li[id|=radical] img {
     width: 25px;
-    height: 25px
+    height: 25px;
 }
 
-.wk_namespace ul.multi-character-grid li[id|=radical] ul>li:first-child {
-    display: none !important
+.wk_namespace ul.multi-character-grid li[id|=radical] ul > li:first-child {
+    display: none !important;
 }
 
-.wk_namespace ul.multi-character-grid li[id|=radical] ul>li:last-child {
-    line-height: 2.6em
+.wk_namespace ul.multi-character-grid li[id|=radical] ul > li:last-child {
+    line-height: 2.6em;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item {
     display: block;
     width: 100%;
     text-align: left;
-    border-left: none
+    border-left: none;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item a {
-    padding: 12px
+    padding: 12px;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item span.character {
     font-size: 27px;
-    line-height: 1em
+    line-height: 1em;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item ul {
-    display: inline-block;
+    display: block;
     float: right;
     text-align: right;
-    font-size: 10px
+    font-size: 10px;
 }
 
-.wk_namespace ul.multi-character-grid li.character-item ul>li {
-    line-height: 1.4em
+.wk_namespace ul.multi-character-grid li.character-item ul > li {
+    line-height: 1.4em;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item.burned {
     border-left: 0;
-    -webkit-box-shadow: 0 5px 5px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow: 0 5px 5px rgba(0,0,0,0.4) inset;
-    box-shadow: 0 5px 5px rgba(0,0,0,0.4) inset
+    box-shadow: 0 5px 5px rgba(0, 0, 0, 0.4) inset;
 }
 
 .wk_namespace ul.multi-character-grid li.character-item:active {
-    -webkit-box-shadow: 0 8px 8px rgba(0,0,0,0.4) inset;
-    -moz-box-shadow: 0 8px 8px rgba(0,0,0,0.4) inset;
-    box-shadow: 0 8px 8px rgba(0,0,0,0.4) inset
+    box-shadow: 0 8px 8px rgba(0, 0, 0, 0.4) inset;
 }
 
 .wk_namespace ul.multi-character-grid span.recently-unlocked-badge:before {
     top: 1.1em;
     left: -1.1em;
     font-size: 11px;
-    text-align: center
+    text-align: center;
 }
 
 .wk_namespace ul.multi-character-grid-extra-styling {
-    -webkit-border-radius: 3px;
-    -moz-border-radius: 3px;
     border-radius: 3px;
-    -webkit-box-shadow: 0 2px 0 rgba(0,0,0,0.3);
-    -moz-box-shadow: 0 2px 0 rgba(0,0,0,0.3);
-    box-shadow: 0 2px 0 rgba(0,0,0,0.3)
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .wk_namespace ul.multi-character-grid-extra-styling li.character-item:first-child {
-    -webkit-border-top-left-radius: 3px;
-    -moz-border-radius-topleft: 3px;
     border-top-left-radius: 3px;
-    -webkit-border-top-right-radius: 3px;
-    -moz-border-radius-topright: 3px;
-    border-top-right-radius: 3px
+    border-top-right-radius: 3px;
 }
 
 .wk_namespace ul.multi-character-grid-extra-styling li.character-item:last-child {
-    -webkit-border-bottom-left-radius: 3px;
-    -moz-border-radius-bottomleft: 3px;
     border-bottom-left-radius: 3px;
-    -webkit-border-bottom-right-radius: 3px;
-    -moz-border-radius-bottomright: 3px;
-    border-bottom-right-radius: 3px
+    border-bottom-right-radius: 3px;
 }
 
-
-@media (max-width: 767px)
-{
-    .wk_namespace ul.single-character-grid li[id|=radical] img
-    {
-        width:25px;
-        height:25px
+@media (max-width: 767px) {
+    .wk_namespace ul.single-character-grid li[id|=radical] img {
+        width: 25px;
+        height: 25px;
     }
 
-    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:first-child
-    {
-        display:none !important
+    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:first-child {
+        display: none !important;
     }
 
-    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:last-child
-    {
-        line-height:2.6em
+    .wk_namespace ul.single-character-grid li[id|=radical] ul>li:last-child {
+        line-height: 2.6em;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item
-    {
-        display:block;
-        width:100%;
-        text-align:left;
-        border-left:none
+    .wk_namespace ul.single-character-grid li.character-item {
+        display: block;
+        width: 100%;
+        text-align: left;
+        border-left: none;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item a
-    {
-        padding:12px
+    .wk_namespace ul.single-character-grid li.character-item a {
+        padding: 12px;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item span.character
-    {
-        font-size:27px;
-        line-height:1em
+    .wk_namespace ul.single-character-grid li.character-item span.character {
+        font-size: 27px;
+        line-height: 1em;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item ul
-    {
-        display:inline-block;
-        float:right;
-        text-align:right;
-        font-size:10px
+    .wk_namespace ul.single-character-grid li.character-item ul {
+        display: block;
+        float: right;
+        text-align: right;
+        font-size: 10px;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item ul>li
-    {
-        line-height:1.4em
+    .wk_namespace ul.single-character-grid li.character-item ul > li {
+        line-height: 1.4em;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item.burned
-    {
-        border-left:0;
-        -webkit-box-shadow:0 5px 5px rgba(0,0,0,0.4) inset;
-        -moz-box-shadow:0 5px 5px rgba(0,0,0,0.4) inset;
-        box-shadow:0 5px 5px rgba(0,0,0,0.4) inset
+    .wk_namespace ul.single-character-grid li.character-item.burned {
+        border-left: 0;
+        box-shadow: 0 5px 5px rgba(0, 0, 0, 0.4) inset;
     }
 
-    .wk_namespace ul.single-character-grid li.character-item:active
-    {
-        -webkit-box-shadow:0 8px 8px rgba(0,0,0,0.4) inset;
-        -moz-box-shadow:0 8px 8px rgba(0,0,0,0.4) inset;
-        box-shadow:0 8px 8px rgba(0,0,0,0.4) inset
+    .wk_namespace ul.single-character-grid li.character-item:active {
+        box-shadow: 0 8px 8px rgba(0, 0, 0, 0.4) inset;
     }
 
-    .wk_namespace ul.single-character-grid span.recently-unlocked-badge:before
-    {
-        top:1.1em;
-        left:-1.1em;
-        font-size:11px;
-        text-align:center
+    .wk_namespace ul.single-character-grid span.recently-unlocked-badge:before {
+        top: 1.1em;
+        left: -1.1em;
+        font-size: 11px;
+        text-align: center;
     }
 }
 
-.wk_namespace ul.multi-character-grid-extra-styling-767px
-{
-    -webkit-border-radius:3px;
-    -moz-border-radius:3px;
-    border-radius:3px;
-    -webkit-box-shadow:0 2px 0 rgba(0,0,0,0.3);
-    -moz-box-shadow:0 2px 0 rgba(0,0,0,0.3);
-    box-shadow:0 2px 0 rgba(0,0,0,0.3)
+.wk_namespace ul.multi-character-grid-extra-styling-767px {
+    border-radius: 3px;
+    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 }
 
-.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:first-child
-{
-    -webkit-border-top-left-radius:3px;
-    -moz-border-radius-topleft:3px;
-    border-top-left-radius:3px;
-    -webkit-border-top-right-radius:3px;
-    -moz-border-radius-topright:3px;
-    border-top-right-radius:3px}
-
-.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:last-child
-{
-    -webkit-border-bottom-left-radius:3px;
-    -moz-border-radius-bottomleft:3px;
-    border-bottom-left-radius:3px;
-    -webkit-border-bottom-right-radius:3px;
-    -moz-border-radius-bottomright:3px;
-    border-bottom-right-radius:3px
+.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:first-child {
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
 }
 
-
-.wk_namespace .recently-unlocked-badge
-{
-    position:absolute;
-    left:0
+.wk_namespace ul.multi-character-grid-extra-styling-767px li.character-item:last-child {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
 }
 
-.wk_namespace .recently-unlocked-badge:before
-{
-    display:block;
-    position:absolute;
-    top:-0.6em;
-    left:-0.6em;
-    width:2em;
-    height:2em;
-    color:#fff;
-    font-size:16px;
-    font-weight:normal;
-    line-height:2.2em;
-    text-shadow:0 2px 0 #99001f;
-    -webkit-box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    -moz-box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    -webkit-border-radius:50%;
-    -moz-border-radius:50%;
-    border-radius:50%;
-    z-index:999
+.wk_namespace .recently-unlocked-badge {
+    position: absolute;
+    left: 0;
+}
+
+.wk_namespace .recently-unlocked-badge:before {
+    display: block;
+    position: absolute;
+    top: -0.6em;
+    left: -0.6em;
+    width: 2em;
+    height: 2em;
+    color: #fff;
+    font-size: 16px;
+    font-weight: normal;
+    line-height: 2.2em;
+    text-shadow: 0 2px 0 #99001f;
+    box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.2) inset, 0 0 10px rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    z-index: 999;
 }

--- a/styles/css/chargrid.css
+++ b/styles/css/chargrid.css
@@ -123,6 +123,20 @@
     text-decoration: none;
 }
 
+.wk_niai ul.single-character-grid li.character-item a::after,
+.wk_niai ul.multi-character-grid li.character-item a::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: #0000;
+    pointer-events: none;
+    border: 1px solid;
+    border-color: #FFF6 #0000 #3336 #FFF6;
+}
+
 .wk_namespace ul.single-character-grid li.character-item ul,
 .wk_namespace ul.multi-character-grid li.character-item ul {
     margin: 0;

--- a/wanikani-similar-kanji/css/wk_niai.css
+++ b/wanikani-similar-kanji/css/wk_niai.css
@@ -13,9 +13,6 @@
     background-color: #0a2;
     background-image: linear-gradient(to bottom, #0c4, #092);
     background-repeat: repeat-x;
-    border-top: 1px solid #0c4;
-    border-bottom: 1px solid #092;
-    border-left: 1px solid #0c4
 }
 
 @media (max-width: 767px) {

--- a/wanikani-similar-kanji/css/wk_niai.css
+++ b/wanikani-similar-kanji/css/wk_niai.css
@@ -1,57 +1,53 @@
-/* #f0a -> 0c4, #dd0093 -> 092 */
-.wk_namespace ul.single-character-grid li[id|=selfkanji]
-{
-    background-color:#0a2;
-    background-image:-moz-linear-gradient(top, #0c4, #092);
-    background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#0c4), to(#092));
-    background-image:-webkit-linear-gradient(top, #0c4, #092);
-    background-image:-o-linear-gradient(top, #0c4, #092);
-    background-image:linear-gradient(to bottom, #0c4, #092);
-    background-repeat:repeat-x;
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF00CC44', endColorstr='#FF009922', GradientType=0);
-    border-top:1px solid #0c4;
-    border-bottom:1px solid #092;
-    border-left:1px solid #0c4
+.wk_namespace .item-info-injector {
+    line-height: revert;
 }
 
-@media (max-width: 767px)
-{
-    .wk_namespace ul.single-character-grid span.delete-badge:before
-    {
+.wk_namespace #kanji-dropdown {
+    width: 100%;
+    display: inline-block;
+    max-width: 126px;
+}
+
+/* #f0a -> 0c4, #dd0093 -> 092 */
+.wk_namespace ul.single-character-grid li[id|=selfkanji] {
+    background-color: #0a2;
+    background-image: linear-gradient(to bottom, #0c4, #092);
+    background-repeat: repeat-x;
+    border-top: 1px solid #0c4;
+    border-bottom: 1px solid #092;
+    border-left: 1px solid #0c4
+}
+
+@media (max-width: 767px) {
+    .wk_namespace ul.single-character-grid span.delete-badge:before {
         top: -0.5em;
         right: -0.5em;
-        font-size:11px;
-        text-align:center;
+        font-size: 11px;
+        text-align: center;
         line-height: 1.45em;
     }
 }
 
-.wk_namespace .delete-badge
-{
-    position:absolute;
-    right:0
+.wk_namespace .delete-badge {
+    position: absolute;
+    right: 0
 }
 
-.wk_namespace .delete-badge:before
-{
+.wk_namespace .delete-badge:before {
     content: "×";
     background-color: orangered;
-    display:block;
-    position:absolute;
-    top:-0.25em;
-    right:-0.25em;
-    width:1.5em;
-    height:1.5em;
-    color:#fff;
-    font-size:16px;
-    font-weight:bold;
-    line-height:1.2em;
-    text-shadow:0 2px 0 #99001f;
-    -webkit-box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    -moz-box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    box-shadow:0 -2px 0 rgba(0,0,0,0.2) inset,0 0 10px rgba(255,255,255,0.5);
-    -webkit-border-radius:50%;
-    -moz-border-radius:50%;
-    border-radius:50%;
-    z-index:99
+    display: block;
+    position: absolute;
+    top: -0.25em;
+    right: -0.25em;
+    width: 1.5em;
+    height: 1.5em;
+    color: #fff;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1.2em;
+    text-shadow: 0 2px 0 #99001f;
+    box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.2) inset, 0 0 10px rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    z-index: 99
 }

--- a/wanikani-similar-kanji/wk_niai.db.js
+++ b/wanikani-similar-kanji/wk_niai.db.js
@@ -148,6 +148,7 @@ function NiaiDB()
             let item = index[sim_kanji];
             if (item) {
                 $(`li[id$="${sim_kanji}"]`).toggleClass(`locked`, !item.assignments?.unlocked_at);
+                $(`li[id$="${sim_kanji}"] li.niai_reading`).text(item.data.readings.find(ri => ri.primary).reading);
                 $(`li[id$="${sim_kanji}"] li.niai_meaning`).text(item.data.meanings[0].meaning);
                 $(`li[id$="${sim_kanji}"] span.character`).attr(`title`, `WK Level: ${item.data.level}`);
             }

--- a/wanikani-similar-kanji/wk_niai.db.js
+++ b/wanikani-similar-kanji/wk_niai.db.js
@@ -99,8 +99,8 @@ function NiaiDB()
 
                             if (!this.isKanjiInDB(sim_kanji))
                             {
-                                console.log("Ignoring", kanji, ", not in DB yet!");
-                                return;
+                                console.log("Ignoring", sim_kanji, ", not in DB yet!");
+                                return; // equivalent to continue
                             }
 
                             const old_score = (sim_kanji in similar_kanji ?

--- a/wanikani-similar-kanji/wk_niai.html.js
+++ b/wanikani-similar-kanji/wk_niai.html.js
@@ -72,7 +72,6 @@
                                         </li>
                                         <li class="divider"></li>
                                         <li><span class="input-prepend" style="margin-bottom: 0;">
-                                                <span class="add-on">漢</span>
                                                 <textarea id="niai_add_similar_input" maxlength="1" rows="1" class="span2" type="text" placeholder="Enter Kanji Here"></textarea>
                                             </span>
                                         </li>
@@ -99,7 +98,7 @@
             .append($view_btn)
             .append($head_btn);
 
-        const $head = $(`<h2>Visually Similar Kanji</h2>`)
+        const $head = $(`<h2>Niai Visually Similar Kanji</h2>`)
                       .append($head_grp);
 
         $section.append($head);

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -230,9 +230,9 @@ function WK_Niai()
         // Main hook, WK Item Info Injector will kick off this script once the
         // page is ready and we can access the subject of the page.
         this.wkItemInfoRef = (window.unsafeWindow || window).wkItemInfo;
-        if (wkItemInfoRef) {
-            wkItemInfoRef.on(`itemPage,lessonQuiz,review,extraStudy`).forType(`kanji`).under(`reading`).spoiling(`meaning,reading`).notifyWhenVisible(this.injectNiaiSection.bind(this));
-            wkItemInfoRef.on(`lesson`).forType(`kanji`).under(`examples`).notifyWhenVisible(this.injectNiaiSection.bind(this));
+        if (this.wkItemInfoRef) {
+            this.wkItemInfoRef.on(`itemPage,lessonQuiz,review,extraStudy`).forType(`kanji`).under(`reading`).spoiling(`meaning,reading`).notifyWhenVisible(this.injectNiaiSection.bind(this));
+            this.wkItemInfoRef.on(`lesson`).forType(`kanji`).under(`examples`).notifyWhenVisible(this.injectNiaiSection.bind(this));
         }
         // #####################################################################
     };

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -21,7 +21,7 @@ function WK_Niai()
             {"id": "override_db",    "base_score": 0.0}
         ],
         "user_level": 99,
-        "min_score": 0.4
+        "min_score": 0.3
     };
 }
 // #############################################################################
@@ -37,7 +37,7 @@ function WK_Niai()
         this.log(`Injecting similar kanji section (callback works).`);
 
         let niaiSection = this.createNiaiSection()[0].children;
-        let section = injectorState.injector.append([...niaiSection[0].childNodes], niaiSection[1], {injectImmediately: true, sectionName: `Visually Similar Kanji`});
+        let section = injectorState.injector.append([...niaiSection[0].childNodes], niaiSection[1], {injectImmediately: true, sectionName: `Niai Visually Similar Kanji`});
         if (!section) return;
         section.classList.add(GM_info.script.namespace, `col1`);
         section.id = `niai_section`;
@@ -189,7 +189,7 @@ function WK_Niai()
     WK_Niai.prototype.init = function()
     {
         GM_addStyle(GM_getResourceText(`niai_style`)
-                        .replace(/\.wk_namespace/g, `#niai_section#niai_section#niai_section#niai_section`));
+                        .replace(/\.wk_namespace/g, `#niai_section`));
 
         this.settings.debug      = GM_getValue(`debug`)      || false;
         this.settings.minify     = GM_getValue(`minify`)     || false;
@@ -202,9 +202,14 @@ function WK_Niai()
 
         this.ndb = new NiaiDB();
 
+        // NOTE: options does not seem to be defined, and analyticsOptions is defined but has only the api key as a value, no current level
+        //       so this section will always run, set settings.user_level to 99, then use open framework to get the actual level
         if (typeof options !== `undefined` || typeof analyticsOptions !== `undefined`)
         {
-            this.settings.user_level = (typeof options !== `undefined` ? options : analyticsOptions)[`Current Level`];
+            this.settings.user_level = (typeof options !== `undefined` ? options : analyticsOptions)[`Current Level`] ?? this.settings.user_level;
+            if (this.settings.user_level > 60) {
+                this.settings.user_level = wkof.user.level;
+            }
             GM_setValue(`user_level`, this.settings.user_level);
         }
 
@@ -235,13 +240,10 @@ function WK_Niai()
     WK_Niai.prototype.run = function()
     {
         // Add scripts with guarding namespace (selecting class/id)
-        let bootstrapcss = GM_getResourceText(`bootstrapcss`);
-        GM_addStyle(bootstrapcss
-                        .replace(/\.wk_namespace/g, `#niai_section#niai_section#niai_section#niai_section`));
-        GM_addStyle(bootstrapcss
+        GM_addStyle(GM_getResourceText(`bootstrapcss`)
                         .replace(/wk_namespace/g, GM_info.script.namespace));
         GM_addStyle(GM_getResourceText(`chargrid`)
-                        .replace(/\.wk_namespace/g, `#niai_section#niai_section#niai_section#niai_section`));
+                        .replace(/wk_namespace/g, GM_info.script.namespace));
 
         // #####################################################################
         // Add parts of bootstrap for the modal pages (settings, etc.)
@@ -263,7 +265,7 @@ function WK_Niai()
 
 // #############################################################################
 // #############################################################################
-let promise = typeof wkof !== `undefined` ? (wkof.include(`Jquery`), wkof.ready(`Jquery`)) : new Promise(r => r());
+let promise = typeof wkof !== `undefined` ? (wkof.include(`Jquery, Apiv2`), wkof.ready(`Jquery, Apiv2`)) : new Promise(r => r());
 
 promise.then(() => {
     const wk_niai = new WK_Niai();

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -108,7 +108,7 @@ function WK_Niai()
     };
 
     // #########################################################################
-    WK_Niai.prototype.populateNiaiSection = function(kanji, curPage)
+    WK_Niai.prototype.populateNiaiSection = function(kanji, curPage = this.wkItemInfoRef.currentState.on)
     {
         $(`#niai_similar_grid`).empty();
 
@@ -172,8 +172,10 @@ function WK_Niai()
         else
             $(`#niai_reset_similar_btn`).addClass(`disabled`);
 
-        if (curPage !== `itemInfo`)
+        if (curPage !== `itemPage`)
             $(`.niai_similar_link`).attr(`target`, `_blank`);
+        else
+            $(`.niai_similar_link:not(li.notInWK a)`).attr(`data-turbo-frame`, `_blank`);
 
         $(`li.notInWK a`).attr(`target`, `_blank`);
         // #####################################################################
@@ -227,10 +229,10 @@ function WK_Niai()
         // #####################################################################
         // Main hook, WK Item Info Injector will kick off this script once the
         // page is ready and we can access the subject of the page.
-        let wkItemInfo = (window.unsafeWindow || window).wkItemInfo;
-        if (wkItemInfo) {
-            wkItemInfo.on(`itemPage,lessonQuiz,review,extraStudy`).forType(`kanji`).under(`reading`).spoiling(`meaning,reading`).notifyWhenVisible(this.injectNiaiSection.bind(this));
-            wkItemInfo.on(`lesson`).forType(`kanji`).under(`examples`).notifyWhenVisible(this.injectNiaiSection.bind(this));
+        this.wkItemInfoRef = (window.unsafeWindow || window).wkItemInfo;
+        if (wkItemInfoRef) {
+            wkItemInfoRef.on(`itemPage,lessonQuiz,review,extraStudy`).forType(`kanji`).under(`reading`).spoiling(`meaning,reading`).notifyWhenVisible(this.injectNiaiSection.bind(this));
+            wkItemInfoRef.on(`lesson`).forType(`kanji`).under(`examples`).notifyWhenVisible(this.injectNiaiSection.bind(this));
         }
         // #####################################################################
     };

--- a/wanikani-similar-kanji/wk_niai.main.js
+++ b/wanikani-similar-kanji/wk_niai.main.js
@@ -204,14 +204,8 @@ function WK_Niai()
 
         this.ndb = new NiaiDB();
 
-        // NOTE: options does not seem to be defined, and analyticsOptions is defined but has only the api key as a value, no current level
-        //       so this section will always run, set settings.user_level to 99, then use open framework to get the actual level
-        if (typeof options !== `undefined` || typeof analyticsOptions !== `undefined`)
-        {
-            this.settings.user_level = (typeof options !== `undefined` ? options : analyticsOptions)[`Current Level`] ?? this.settings.user_level;
-            if (this.settings.user_level > 60) {
-                this.settings.user_level = wkof.user.level;
-            }
+        if (this.settings.user_level > 60 || this.settings.user_level < wkof.user.level) {
+            this.settings.user_level = wkof.user.level;
             GM_setValue(`user_level`, this.settings.user_level);
         }
 

--- a/wanikani-similar-kanji/wk_niai.modal.js
+++ b/wanikani-similar-kanji/wk_niai.modal.js
@@ -89,7 +89,7 @@
                 .replace(/[\p{scx=Hiragana}\p{scx=Katakana}\w\s]/gu, '')
                 .trim();
             if (k) {
-                this.populateNiaiSection(k, '');
+                this.populateNiaiSection(k);
             }
         });
 

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.30
+// @version     1.3.32
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -22,7 +22,7 @@
 //
 // @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/7e1d846282c6d962fbe28b6e3a8c0b50a61220c9/wanikani-similar-kanji/css/wk_niai.css
 //
-// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/7e1d846282c6d962fbe28b6e3a8c0b50a61220c9/styles/css/chargrid.css
+// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/363e9df4f60015b1d33ca61e653572ac232b0080/styles/css/chargrid.css
 // @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/bootstrap/css/bootstrap.crop.css
 //
 // @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
@@ -31,9 +31,9 @@
 // @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=1276693
 //
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.db.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/wk_niai.modal.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/0691a2c5d05338606f731ea9f98e0b2dbd18c784/wanikani-similar-kanji/wk_niai.modal.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.html.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.main.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/0691a2c5d05338606f731ea9f98e0b2dbd18c784/wanikani-similar-kanji/wk_niai.main.js
 //
 // @grant       GM_log
 // @grant       GM_getValue

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.33
+// @version     1.3.34
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -22,7 +22,7 @@
 //
 // @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/7e1d846282c6d962fbe28b6e3a8c0b50a61220c9/wanikani-similar-kanji/css/wk_niai.css
 //
-// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/90099f79ce5d95ffcb834c3de54d8275be7d1f57/styles/css/chargrid.css
+// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/0e0833ee8175b903d34108210759c1a457408833/styles/css/chargrid.css
 // @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/bootstrap/css/bootstrap.crop.css
 //
 // @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.32
+// @version     1.3.33
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -22,7 +22,7 @@
 //
 // @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/7e1d846282c6d962fbe28b6e3a8c0b50a61220c9/wanikani-similar-kanji/css/wk_niai.css
 //
-// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/363e9df4f60015b1d33ca61e653572ac232b0080/styles/css/chargrid.css
+// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/90099f79ce5d95ffcb834c3de54d8275be7d1f57/styles/css/chargrid.css
 // @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/bootstrap/css/bootstrap.crop.css
 //
 // @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
@@ -33,7 +33,7 @@
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.db.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/0691a2c5d05338606f731ea9f98e0b2dbd18c784/wanikani-similar-kanji/wk_niai.modal.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.html.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/0691a2c5d05338606f731ea9f98e0b2dbd18c784/wanikani-similar-kanji/wk_niai.main.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/90099f79ce5d95ffcb834c3de54d8275be7d1f57/wanikani-similar-kanji/wk_niai.main.js
 //
 // @grant       GM_log
 // @grant       GM_getValue

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.35
+// @version     1.3.36
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -33,7 +33,7 @@
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/e57d0de325d2c020da8723df1bac4c0035dc88db/wanikani-similar-kanji/wk_niai.db.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/0691a2c5d05338606f731ea9f98e0b2dbd18c784/wanikani-similar-kanji/wk_niai.modal.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.html.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/90099f79ce5d95ffcb834c3de54d8275be7d1f57/wanikani-similar-kanji/wk_niai.main.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/b5f681f7f94aaa48caa6927a3a5c6a17d39739d8/wanikani-similar-kanji/wk_niai.main.js
 //
 // @grant       GM_log
 // @grant       GM_getValue

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.25
+// @version     1.3.29
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -20,20 +20,20 @@
 // @resource    manual_db      https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/db/manual_esc.json
 // @resource    lookup_db      https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/db/lookup_esc.json
 //
-// @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/css/wk_niai.css
+// @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/css/wk_niai.css
 //
-// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/9e2c7070a8f277dcb372d2e04c60136cea14f81a/styles/css/chargrid.css
-// @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/3ecdbcadd04d0832ab98540eea5f918489841f41/styles/bootstrap/css/bootstrap.crop.css
+// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/css/chargrid.css
+// @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/bootstrap/css/bootstrap.crop.css
 //
 // @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js
 // @resource    b-dropdown-js  https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap-dropdown.js
 //
 // @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=1276693
 //
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/wk_niai.db.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.db.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/wk_niai.modal.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/wk_niai.html.js
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/3ecdbcadd04d0832ab98540eea5f918489841f41/wanikani-similar-kanji/wk_niai.main.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.html.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.main.js
 //
 // @grant       GM_log
 // @grant       GM_getValue

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.29
+// @version     1.3.30
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
 // @namespace   wk_niai
 //
-// @match        https://www.wanikani.com/*
-// @match        https://preview.wanikani.com/*
+// @match       https://www.wanikani.com/*
+// @match       https://preview.wanikani.com/*
 //
 // @updateURL   https://github.com/mwil/wanikani-userscripts/raw/master/wanikani-similar-kanji/wk_niai.user.js
 // @downloadURL https://github.com/mwil/wanikani-userscripts/raw/master/wanikani-similar-kanji/wk_niai.user.js
@@ -20,9 +20,9 @@
 // @resource    manual_db      https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/db/manual_esc.json
 // @resource    lookup_db      https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/wanikani-similar-kanji/db/lookup_esc.json
 //
-// @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/css/wk_niai.css
+// @resource    niai_style     https://raw.githubusercontent.com/mwil/wanikani-userscripts/7e1d846282c6d962fbe28b6e3a8c0b50a61220c9/wanikani-similar-kanji/css/wk_niai.css
 //
-// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/css/chargrid.css
+// @resource    chargrid       https://raw.githubusercontent.com/mwil/wanikani-userscripts/7e1d846282c6d962fbe28b6e3a8c0b50a61220c9/styles/css/chargrid.css
 // @resource    bootstrapcss   https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/styles/bootstrap/css/bootstrap.crop.css
 //
 // @resource    bootstrap-js   https://raw.githubusercontent.com/mwil/wanikani-userscripts/8ee517737d604f1df0ff103a33b69f1f07218815/styles/bootstrap/js/bootstrap.js

--- a/wanikani-similar-kanji/wk_niai.user.js
+++ b/wanikani-similar-kanji/wk_niai.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Wanikani Niai Similar Kanji
-// @version     1.3.34
+// @version     1.3.35
 // @author      acm
 // @description Adds a visually similar kanji section to content pages, reviews, and lessons
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
@@ -30,7 +30,7 @@
 //
 // @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=1276693
 //
-// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.db.js
+// @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/e57d0de325d2c020da8723df1bac4c0035dc88db/wanikani-similar-kanji/wk_niai.db.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/0691a2c5d05338606f731ea9f98e0b2dbd18c784/wanikani-similar-kanji/wk_niai.modal.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/45e295823c7d6d40630ddd14c95a78df093fb296/wanikani-similar-kanji/wk_niai.html.js
 // @require     https://raw.githubusercontent.com/mwil/wanikani-userscripts/90099f79ce5d95ffcb834c3de54d8275be7d1f57/wanikani-similar-kanji/wk_niai.main.js


### PR DESCRIPTION
My reasons for updating the style are the same as what I said in #27.

The issues I found were:
* An issue where `sim_kanji` was not the variable that would be logged while going through the databases resulting in confusing messages saying the same root kanji was not in the database.
* An issue where the user's level would never be correctly set, it would always be undefined or 99. This wasn't apparent due to the wkof cache refresh updating the styles for locked items.
* The bootstrap injection was duplicated, once with the namespace and once with the section id.
* The default minimum score was different in two places.
* `curPage` had no default set and there was only 1 instance out of all calls to it where it was passed an explicit value.
* "itemInfo" was used as the string to compare to but isn't a possible value of `curPage` so I assume it was meant to be "itemPage"
* script would not actually update the stored user level with their current user level. With the change to use open framework to check for the current level, this is now easier to do.